### PR TITLE
Add a Newtype instance to StatusCode

### DIFF
--- a/src/Affjax/StatusCode.purs
+++ b/src/Affjax/StatusCode.purs
@@ -1,11 +1,13 @@
 module Affjax.StatusCode where
 
 import Prelude
+import Data.Newtype (class Newtype)
 
 newtype StatusCode = StatusCode Int
 
 derive instance eqStatusCode :: Eq StatusCode
 derive instance ordStatusCode :: Ord StatusCode
+derive instance newtypeStatusCode :: Newtype StatusCode _
 
 instance showStatusCode :: Show StatusCode where
   show (StatusCode code) = "(StatusCode " <> show code <> ")"


### PR DESCRIPTION
Makes it easier for users of the library to access the underlying
statuscode with `unwrap`.