### PR TITLE
throw timeout error not as `XHRError Exn.Error`, but as separate error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes (😱!!!):
 
+- `XHRError Exn.Error` was removed and split to `TimeoutError`, `RequestFailedError`, `XHROtherError Exn.Error` (#155, @srghma)
+
 New features:
 
 Bugfixes:

--- a/src/Affjax.js
+++ b/src/Affjax.js
@@ -41,7 +41,7 @@ exports._ajax = function () {
     };
   }
 
-  return function (mkHeader, options) {
+  return function (timeoutErrorMessageIdent, requestFailedMessageIdent, mkHeader, options) {
     return function (errback, callback) {
       var xhr = platformSpecific.newXHR();
       var fixedUrl = platformSpecific.fixupUrl(options.url, xhr);
@@ -56,13 +56,13 @@ exports._ajax = function () {
           errback(e);
         }
       }
-      var onerror = function (msg) {
+      var onerror = function (msgIdent) {
         return function () {
-          errback(new Error(msg + ": " + options.method + " " + options.url));
+          errback(new Error(msgIdent));
         };
       };
-      xhr.onerror = onerror("AJAX request failed");
-      xhr.ontimeout = onerror("AJAX request timed out");
+      xhr.onerror = onerror(requestFailedMessageIdent);
+      xhr.ontimeout = onerror(timeoutErrorMessageIdent);
       xhr.onload = function () {
         callback({
           status: xhr.status,

--- a/src/Affjax.purs
+++ b/src/Affjax.purs
@@ -30,7 +30,7 @@ import Data.Either (Either(..), either, note)
 import Data.Foldable (any)
 import Data.FormURLEncoded as FormURLEncoded
 import Data.Function (on)
-import Data.Function.Uncurried (Fn2, runFn2)
+import Data.Function.Uncurried (Fn4, runFn4)
 import Data.HTTP.Method (Method(..), CustomMethod)
 import Data.HTTP.Method as Method
 import Data.List.NonEmpty as NEL
@@ -88,7 +88,9 @@ defaultRequest =
 data Error
   = RequestContentError String
   | ResponseBodyError ForeignError (Response Foreign)
-  | XHRError Exn.Error
+  | TimeoutError
+  | RequestFailedError
+  | XHROtherError Exn.Error
 
 printError :: Error -> String
 printError = case _ of
@@ -96,7 +98,11 @@ printError = case _ of
     "There was a problem with the request content: " <> err
   ResponseBodyError err _ ->
     "There was a problem with the response body: " <> renderForeignError err
-  XHRError err ->
+  TimeoutError ->
+    "There was a problem making the request: timeout"
+  RequestFailedError ->
+    "There was a problem making the request: request failed"
+  XHROtherError err ->
     "There was a problem making the request: " <> Exn.message err
 
 -- | The type of records that represents a received HTTP response.
@@ -179,16 +185,19 @@ request req =
         Left err ->
           pure $ Left (RequestContentError err)
   where
-
   send :: Nullable Foreign -> Aff (Either Error (Response a))
   send content =
-    try (AC.fromEffectFnAff (runFn2 _ajax ResponseHeader (ajaxRequest content))) <#> case _ of
+    try (AC.fromEffectFnAff (runFn4 _ajax timeoutErrorMessageIdent requestFailedMessageIdent ResponseHeader (ajaxRequest content))) <#> case _ of
       Right res ->
         case runExcept (fromResponse res.body) of
           Left err -> Left (ResponseBodyError (NEL.head err) res)
           Right body -> Right (res { body = body })
       Left err ->
-        Left (XHRError err)
+        let message = Exn.message err
+          in Left $
+          if message == timeoutErrorMessageIdent then TimeoutError
+          else if message == requestFailedMessageIdent then RequestFailedError
+          else XHROtherError err
 
   ajaxRequest :: Nullable Foreign -> AjaxRequest a
   ajaxRequest =
@@ -227,6 +236,12 @@ request req =
       addHeader (Accept <$> ResponseFormat.toMediaType req.responseFormat)
         req.headers
 
+  timeoutErrorMessageIdent :: String
+  timeoutErrorMessageIdent = "AffjaxTimeoutErrorMessageIdent"
+
+  requestFailedMessageIdent :: String
+  requestFailedMessageIdent = "AffjaxRequestFailedMessageIdent"
+
   addHeader :: Maybe RequestHeader -> Array RequestHeader -> Array RequestHeader
   addHeader mh hs = case mh of
     Just h | not $ any (on eq RequestHeader.name h) hs -> hs `Arr.snoc` h
@@ -260,7 +275,9 @@ type AjaxRequest a =
 
 foreign import _ajax
   :: forall a
-   . Fn2
+   . Fn4
+      String
+      String
       (String -> String -> ResponseHeader)
       (AjaxRequest a)
       (AC.EffectFnAff (Response Foreign))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -84,8 +84,8 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
 
     A.log "GET /slow with timeout: should return an error"
     (AX.request $ AX.defaultRequest { url = slow, timeout = Just (Milliseconds 100.0) }) >>= assertLeft >>= case _ of
-      AX.XHRError _ → pure unit
-      other → logAny' other *> assertFail "Expected a XHRError"
+      AX.TimeoutError → pure unit
+      other → logAny' other *> assertFail "Expected a TimeoutError"
 
     A.log "POST /mirror: should use the POST method"
     AX.post ResponseFormat.json mirror (Just (RequestBody.string "test")) >>= assertRight >>= \res -> do


### PR DESCRIPTION
**Description of the change**

fixes https://github.com/purescript-contrib/purescript-affjax/issues/155

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
