### PR TITLE
WIP: BadUrlError

### DIFF
--- a/src/Affjax.purs
+++ b/src/Affjax.purs
@@ -91,6 +91,7 @@ data Error
   | ResponseBodyError ForeignError (Response Foreign)
   | TimeoutError
   | RequestFailedError
+  | BadUrlError String
   | XHROtherError Exn.Error
 
 printError :: Error -> String
@@ -103,6 +104,8 @@ printError = case _ of
     "There was a problem making the request: timeout"
   RequestFailedError ->
     "There was a problem making the request: request failed"
+  BadUrlError url ->
+    "There was a problem with the url: " <> url
   XHROtherError err ->
     "There was a problem making the request: " <> Exn.message err
 
@@ -198,6 +201,7 @@ request req =
           in Left $
           if message == timeoutErrorMessageIdent then TimeoutError
           else if message == requestFailedMessageIdent then RequestFailedError
+          else if message == "Request path contains unescaped characters" then BadUrlError req.url
           else XHROtherError err
 
   ajaxRequest :: Nullable Foreign -> AjaxRequest a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -17,7 +17,7 @@ import Effect.Aff.Compat (EffectFnAff, fromEffectFnAff)
 import Effect.Class (liftEffect)
 import Effect.Class.Console as A
 import Effect.Console (log, logShow)
-import Effect.Exception (error, throwException)
+import Effect.Exception as Exn
 import Foreign.Object as FO
 
 foreign import logAny :: forall a. a -> Effect Unit
@@ -30,7 +30,7 @@ logAny' :: forall a. a -> Aff Unit
 logAny' = liftEffect <<< logAny
 
 assertFail :: forall a. String -> Aff a
-assertFail = throwError <<< error
+assertFail = throwError <<< Exn.error
 
 assertMsg :: String -> Boolean -> Aff Unit
 assertMsg _ true = pure unit
@@ -51,7 +51,7 @@ assertEq x y =
   when (x /= y) $ assertFail $ "Expected " <> show x <> ", got " <> show y
 
 main :: Effect Unit
-main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log "affjax: All good!")) do
+main = void $ runAff (either (\e -> logShow e *> Exn.throwException e) (const $ log "affjax: All good!")) do
   let ok200 = StatusCode 200
   let notFound404 = StatusCode 404
 
@@ -105,5 +105,10 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
       -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
     A.log "Testing cancellation"
-    forkAff (AX.post_ mirror (Just (RequestBody.string "do it now"))) >>= killFiber (error "Pull the cord!")
+    forkAff (AX.post_ mirror (Just (RequestBody.string "do it now"))) >>= killFiber (Exn.error "Pull the cord!")
     assertMsg "Should have been canceled" true
+
+    A.log "Testing invalid url"
+    AX.get ResponseFormat.string "/фыва" >>= assertLeft >>= case _ of
+       AX.XHROtherError error → assertEq "Request path contains unescaped characters" (Exn.message error)
+       other → logAny' other *> assertFail "Expected a XHROtherError"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -110,5 +110,5 @@ main = void $ runAff (either (\e -> logShow e *> Exn.throwException e) (const $ 
 
     A.log "Testing invalid url"
     AX.get ResponseFormat.string "/фыва" >>= assertLeft >>= case _ of
-       AX.XHROtherError error → assertEq "Request path contains unescaped characters" (Exn.message error)
-       other → logAny' other *> assertFail "Expected a XHROtherError"
+       AX.BadUrlError url → assertEq "/фыва" url
+       other → logAny' other *> assertFail "Expected a BadUrlError"


### PR DESCRIPTION
**Description of the change**

This pr adds BadUrlError, just like in Elm

https://github.com/elm/http/blob/34a9a27411c2492d3e247ac75cd48e22b473bef5/src/Http.elm#L539

which is thrown during `xhr.open` https://github.com/elm/http/blob/34a9a27411c2492d3e247ac75cd48e22b473bef5/src/Elm/Kernel/Http.js#L33

thought I wasn't been able to reproduce this, instead for me on `spago test` it was thrown on `xhr.send`

the error we are handling is

```
TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
    at new NodeError (node:internal/errors:363:5)
    at new ClientRequest (node:_http_client:154:13)
    at Object.request (node:http:96:10)
    at XMLHttpRequest._sendHxxpRequest (/home/srghma/projects/purescript-affjax/node_modules/xhr2/lib/xhr2.js:480:24)
    at XMLHttpRequest._sendHttp (/home/srghma/projects/purescript-affjax/node_modules/xhr2/lib/xhr2.js:460:14)
    at XMLHttpRequest.send (/home/srghma/projects/purescript-affjax/node_modules/xhr2/lib/xhr2.js:278:18)
    at /home/srghma/projects/purescript-affjax/output/Affjax/foreign.js:89:13
    at __do (/home/srghma/projects/purescript-affjax/output/Effect.Aff.Compat/index.js:15:22)
    at runAsync (/home/srghma/projects/purescript-affjax/output/Effect.Aff/foreign.js:98:20)
    at run (/home/srghma/projects/purescript-affjax/output/Effect.Aff/foreign.js:333:22) {
  code: 'ERR_UNESCAPED_CHARACTERS'
}
```

but maybe there other errors, i'm not sure about this change

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
