### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#167 by @thomashoneyman)
 
 ## [v12.0.0](https://github.com/purescript-contrib/purescript-affjax/releases/tag/v12.0.0) - 2021-02-26
 

--- a/src/Affjax.purs
+++ b/src/Affjax.purs
@@ -1,15 +1,20 @@
 module Affjax
-  ( Request, defaultRequest
+  ( Request
+  , defaultRequest
   , Response
   , Error(..)
   , printError
   , URL
   , request
   , get
-  , post, post_
-  , put, put_
-  , delete, delete_
-  , patch, patch_
+  , post
+  , post_
+  , put
+  , put_
+  , delete
+  , delete_
+  , patch
+  , patch_
   ) where
 
 import Prelude
@@ -194,11 +199,13 @@ request req =
           Left err -> Left (ResponseBodyError (NEL.head err) res)
           Right body -> Right (res { body = body })
       Left err ->
-        let message = Exn.message err
-          in Left $
-          if message == timeoutErrorMessageIdent then TimeoutError
-          else if message == requestFailedMessageIdent then RequestFailedError
-          else XHROtherError err
+        let
+          message = Exn.message err
+        in
+          Left $
+            if message == timeoutErrorMessageIdent then TimeoutError
+            else if message == requestFailedMessageIdent then RequestFailedError
+            else XHROtherError err
 
   ajaxRequest :: Nullable Foreign -> AjaxRequest a
   ajaxRequest =
@@ -257,9 +264,9 @@ request req =
   fromResponse = case req.responseFormat of
     ResponseFormat.ArrayBuffer _ -> unsafeReadTagged "ArrayBuffer"
     ResponseFormat.Blob _ -> unsafeReadTagged "Blob"
-    ResponseFormat.Document _ -> \x →     unsafeReadTagged "Document" x
-                                      <|> unsafeReadTagged "XMLDocument" x
-                                      <|> unsafeReadTagged "HTMLDocument" x
+    ResponseFormat.Document _ -> \x -> unsafeReadTagged "Document" x
+      <|> unsafeReadTagged "XMLDocument" x
+      <|> unsafeReadTagged "HTMLDocument" x
     ResponseFormat.Json coe -> coe <<< parseJSON <=< unsafeReadTagged "String"
     ResponseFormat.String _ -> unsafeReadTagged "String"
     ResponseFormat.Ignore coe -> const $ coe (pure unit)
@@ -280,8 +287,8 @@ type AjaxRequest a =
 foreign import _ajax
   :: forall a
    . Fn4
-      String
-      String
-      (String -> String -> ResponseHeader)
-      (AjaxRequest a)
-      (AC.EffectFnAff (Response Foreign))
+       String
+       String
+       (String -> String -> ResponseHeader)
+       (AjaxRequest a)
+       (AC.EffectFnAff (Response Foreign))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -55,7 +55,7 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
   let ok200 = StatusCode 200
   let notFound404 = StatusCode 404
 
-  { server, port } ← fromEffectFnAff startServer
+  { server, port } <- fromEffectFnAff startServer
   finally (fromEffectFnAff (stopServer server)) do
     A.log ("Test server running on port " <> show port)
 
@@ -75,8 +75,8 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
 
     A.log "GET /not-json: invalid JSON with Foreign response should return an error"
     AX.get ResponseFormat.json doesNotExist >>= assertLeft >>= case _ of
-      AX.ResponseBodyError _ _ → pure unit
-      other → logAny' other *> assertFail "Expected a ResponseBodyError"
+      AX.ResponseBodyError _ _ -> pure unit
+      other -> logAny' other *> assertFail "Expected a ResponseBodyError"
 
     A.log "GET /not-json: invalid JSON with String response should be ok"
     AX.get ResponseFormat.string notJson >>= assertRight >>= \res -> do
@@ -84,8 +84,8 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
 
     A.log "GET /slow with timeout: should return an error"
     (AX.request $ AX.defaultRequest { url = slow, timeout = Just (Milliseconds 100.0) }) >>= assertLeft >>= case _ of
-      AX.TimeoutError → pure unit
-      other → logAny' other *> assertFail "Expected a TimeoutError"
+      AX.TimeoutError -> pure unit
+      other -> logAny' other *> assertFail "Expected a TimeoutError"
 
     A.log "POST /mirror: should use the POST method"
     AX.post ResponseFormat.json mirror (Just (RequestBody.string "test")) >>= assertRight >>= \res -> do
@@ -102,7 +102,7 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
     A.log "Testing CORS, HTTPS"
     AX.get ResponseFormat.json "https://cors-test.appspot.com/test" >>= assertRight >>= \res -> do
       assertEq ok200 res.status
-      -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
+    -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
     A.log "Testing cancellation"
     forkAff (AX.post_ mirror (Just (RequestBody.string "do it now"))) >>= killFiber (error "Pull the cord!")

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -102,7 +102,6 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
     A.log "Testing CORS, HTTPS"
     AX.get ResponseFormat.json "https://cors-test.appspot.com/test" >>= assertRight >>= \res -> do
       assertEq ok200 res.status
-    -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
     A.log "Testing cancellation"
     forkAff (AX.post_ mirror (Just (RequestBody.string "do it now"))) >>= killFiber (error "Pull the cord!")


### PR DESCRIPTION
**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
