### PR TITLE
Add Pulp and Bower to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,9 @@ jobs:
 
       - name: Check formatting
         run: purs-tidy check src test
+
+      - name: Verify Bower & Pulp
+        run: |
+          npm install bower pulp
+          npx bower install
+          npx pulp build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,5 @@ jobs:
 
       - name: Verify Bower & Pulp
         run: |
-          npm install bower pulp
-          npx bower install
-          npx pulp build
+          npx bower@latest install
+          npx pulp@15.0.0 build

--- a/src/Affjax.purs
+++ b/src/Affjax.purs
@@ -223,7 +223,7 @@ request req =
   extractContent :: RequestBody.RequestBody -> Either String Foreign
   extractContent = case _ of
     RequestBody.ArrayView f ->
-      Right $ f (unsafeToForeign :: forall a. ArrayView a -> Foreign)
+      Right $ f (unsafeToForeign :: forall x. ArrayView x -> Foreign)
     RequestBody.Blob x ->
       Right $ (unsafeToForeign :: Blob -> Foreign) x
     RequestBody.Document x ->


### PR DESCRIPTION
**Description of the change**

Adds Pulp and Bower to CI so that the Bowerfile is exercised the same as the Spago file. This is necessary because we need to ensure our Bowerfile remains valid until the new registry is launched and we can switch over to a `purs.json` manifest file.
